### PR TITLE
fix: Don't block OG images in robots.txt

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3397,9 +3397,9 @@ The implementation follows a **pragmatic, YAGNI-driven approach** that prioritiz
   - [x] OG_IMAGE_VERSION constant for manual design changes
   - [x] Count-based URLs for home/category pages (auto-bust when tools added)
 - [ ] Test OG images in social media debuggers:
-  - [ ] Twitter Card Validator
-  - [ ] LinkedIn Post Inspector
-  - [ ] Facebook Sharing Debugger
+  - [ ] [Twitter Card Validator](https://cards-dev.twitter.com/validator)
+  - [ ] [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/)
+  - [ ] [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)
   - [ ] Slack unfurl preview
 - [ ] Ensure images render correctly on all platforms
 - [ ] Verify edge caching is working (check response headers in production)

--- a/apps/codemata/app/robots.ts
+++ b/apps/codemata/app/robots.ts
@@ -5,7 +5,7 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
-      allow: "/",
+      allow: ["/", "/api/og"],
       disallow: ["/api/", "/_next/"],
     },
     sitemap: getAppUrl("/sitemap.xml"),


### PR DESCRIPTION
## Issue

Was getting this issue from Twitter card preview:

```
INFO:  Page fetched successfully
INFO:  25 metatags were found
INFO:  twitter:card = summary_large_image tag found
INFO:  Card loaded successfully
WARN:  The image URL https://codemata.benmvp.com/api/og?title=YAML+Formatter&description=Quickly+format+and+beautify+your+YAML+files+with+our+free+online+tool.+Fix+indentation+errors%2C+improve+readability%2C+and+ensure+valid+syntax+effortlessly.&v=1 specified by the 'twitter:image' metatag may be restricted by the site's robots.txt file, which will prevent Twitter from fetching it.
```

The `robots.ts` was blocking all `/api` routes but the OG image is at `/api/og`

## Solution

Specifically allow `/api/og`