### PR TITLE
feat(validators): implement HTML Validator with improved layout UX

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3757,12 +3757,12 @@ The implementation follows a **pragmatic, YAGNI-driven approach** that prioritiz
 
 **Goal:** Add validation and checking tools
 
-**Status:** 🚧 In Progress (Phase 9.1 complete, 9.2 starting)
+**Status:** 🚧 In Progress (Phase 9.1-9.4 complete - JSON & HTML validators live)
 
 #### Tools to Build
 
 - [x] JSON Validator (with schema support)
-- [ ] HTML Validator
+- [x] HTML Validator
 - [ ] XML Validator
 - [ ] CSS Validator
 - [ ] Regex Tester
@@ -3783,8 +3783,8 @@ The implementation follows a **pragmatic, YAGNI-driven approach** that prioritiz
 **9.2 Implement Validators** 🚧 In Progress
 
 - [x] JSON Validator
+- [x] HTML Validator (with html-validate, a11y checks, 65/35 layout)
 - [ ] Regex Tester
-- [ ] HTML Validator
 - [ ] CSS Validator
 - [ ] XML Validator
 

--- a/apps/codemata/app/validators/[slug]/page.tsx
+++ b/apps/codemata/app/validators/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { CategoryBackLink } from "@/components/CategoryBackLink";
+import { HtmlValidator } from "@/components/validators/HtmlValidator";
 import { JsonValidator } from "@/components/validators/JsonValidator";
 import { VALIDATOR_TOOLS } from "@/lib/tools-data";
 import { VALIDATOR_EXAMPLES } from "@/lib/validators/examples";
@@ -68,6 +69,22 @@ export default async function ValidatorPage({
             example={VALIDATOR_EXAMPLES.json}
             exampleSchema={VALIDATOR_EXAMPLES.jsonSchema}
           />
+        </div>
+      </div>
+    );
+  }
+
+  // HTML Validator
+  if (slug === "html-validator") {
+    return (
+      <div className="max-w-7xl mx-auto px-4 py-6 md:py-12">
+        <div className="flex flex-col gap-6">
+          <CategoryBackLink href="/validators" label="Validators" />
+          <div>
+            <h1 className="text-3xl md:text-4xl font-bold mb-2">{tool.name}</h1>
+            <p className="text-muted-foreground text-lg">{tool.description}</p>
+          </div>
+          <HtmlValidator example={VALIDATOR_EXAMPLES.html} />
         </div>
       </div>
     );

--- a/apps/codemata/components/validators/HtmlValidator.tsx
+++ b/apps/codemata/components/validators/HtmlValidator.tsx
@@ -62,22 +62,14 @@ export function HtmlValidator({ example }: HtmlValidatorProps) {
     >
       {/* Left Column: Editor + Button */}
       <div className="space-y-4">
-        <div>
-          <label
-            htmlFor="html-input"
-            className="text-sm font-medium mb-2 block"
-          >
-            HTML Input
-          </label>
-          <CodeEditor
-            value={input}
-            onChange={setInput}
-            language="html"
-            extensions={editorExtensions}
-            onViewUpdate={setEditorView}
-            label="HTML Input"
-          />
-        </div>
+        <CodeEditor
+          value={input}
+          onChange={setInput}
+          language="html"
+          extensions={editorExtensions}
+          onViewUpdate={setEditorView}
+          label="HTML Input"
+        />
 
         {/* Validate Button */}
         <div className="flex gap-2">

--- a/apps/codemata/components/validators/HtmlValidator.tsx
+++ b/apps/codemata/components/validators/HtmlValidator.tsx
@@ -1,32 +1,20 @@
 "use client";
 
 import type { EditorView } from "@codemirror/view";
-import { ChevronDown, ChevronUp, Settings } from "lucide-react";
 import { useMemo, useState } from "react";
-import { validateJson } from "@/app/validators/actions";
+import { validateHtml } from "@/app/validators/actions";
 import { CodeEditor } from "@/components/CodeEditor";
 import { Button } from "@/components/ui/button";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
 import { createLinter, scrollToError } from "@/lib/validators/diagnostics";
 import type { ValidationError, ValidationResult } from "@/lib/validators/types";
 import { ValidationResults } from "./ValidationResults";
 
-interface JsonValidatorProps {
+interface HtmlValidatorProps {
   example: string;
-  exampleSchema?: string;
 }
 
-export function JsonValidator({
-  example,
-  exampleSchema = "",
-}: JsonValidatorProps) {
+export function HtmlValidator({ example }: HtmlValidatorProps) {
   const [input, setInput] = useState(example);
-  const [schema, setSchema] = useState(exampleSchema);
-  const [showSchema, setShowSchema] = useState(false);
   const [result, setResult] = useState<ValidationResult | null>(null);
   const [isValidating, setIsValidating] = useState(false);
   const [editorView, setEditorView] = useState<EditorView | null>(null);
@@ -34,10 +22,7 @@ export function JsonValidator({
   const handleValidate = async () => {
     setIsValidating(true);
     try {
-      const validationResult = await validateJson(
-        input,
-        showSchema ? schema : undefined,
-      );
+      const validationResult = await validateHtml(input);
       setResult(validationResult);
     } catch (error) {
       console.error("Validation failed:", error);
@@ -75,23 +60,22 @@ export function JsonValidator({
         result ? "grid grid-cols-1 lg:grid-cols-[65fr_35fr] gap-4" : ""
       }
     >
-      {/* Left Column: Input + Button + Schema */}
+      {/* Left Column: Editor + Button */}
       <div className="space-y-4">
-        {/* JSON Input */}
         <div>
           <label
-            htmlFor="json-input"
+            htmlFor="html-input"
             className="text-sm font-medium mb-2 block"
           >
-            JSON Input
+            HTML Input
           </label>
           <CodeEditor
             value={input}
             onChange={setInput}
-            language="json"
+            language="html"
             extensions={editorExtensions}
             onViewUpdate={setEditorView}
-            label="JSON Input"
+            label="HTML Input"
           />
         </div>
 
@@ -103,47 +87,9 @@ export function JsonValidator({
             className="w-full sm:w-auto"
             size="default"
           >
-            {isValidating ? "Validating..." : "Validate JSON"}
+            {isValidating ? "Validating..." : "Validate HTML"}
           </Button>
         </div>
-
-        {/* Schema (Collapsible) */}
-        <Collapsible open={showSchema} onOpenChange={setShowSchema}>
-          <CollapsibleTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="gap-2 text-muted-foreground hover:text-foreground"
-            >
-              <Settings className="w-4 h-4" />
-              Advanced: Validate Against JSON Schema
-              {showSchema ? (
-                <ChevronUp className="w-4 h-4" />
-              ) : (
-                <ChevronDown className="w-4 h-4" />
-              )}
-            </Button>
-          </CollapsibleTrigger>
-          <CollapsibleContent className="mt-2">
-            <label
-              htmlFor="json-schema"
-              className="text-sm font-medium mb-2 block"
-            >
-              JSON Schema (Optional)
-            </label>
-            <CodeEditor
-              value={schema}
-              onChange={setSchema}
-              language="json"
-              placeholder="Paste JSON Schema here..."
-              label="JSON Schema (Optional)"
-            />
-            <p className="text-xs text-muted-foreground mt-2">
-              Provide a JSON Schema to validate your JSON structure, types, and
-              constraints.
-            </p>
-          </CollapsibleContent>
-        </Collapsible>
       </div>
 
       {/* Right Column: Results */}

--- a/apps/codemata/components/validators/JsonValidator.tsx
+++ b/apps/codemata/components/validators/JsonValidator.tsx
@@ -78,22 +78,14 @@ export function JsonValidator({
       {/* Left Column: Input + Button + Schema */}
       <div className="space-y-4">
         {/* JSON Input */}
-        <div>
-          <label
-            htmlFor="json-input"
-            className="text-sm font-medium mb-2 block"
-          >
-            JSON Input
-          </label>
-          <CodeEditor
-            value={input}
-            onChange={setInput}
-            language="json"
-            extensions={editorExtensions}
-            onViewUpdate={setEditorView}
-            label="JSON Input"
-          />
-        </div>
+        <CodeEditor
+          value={input}
+          onChange={setInput}
+          language="json"
+          extensions={editorExtensions}
+          onViewUpdate={setEditorView}
+          label="JSON Input"
+        />
 
         {/* Validate Button */}
         <div className="flex gap-2">

--- a/apps/codemata/components/validators/ValidationResults.tsx
+++ b/apps/codemata/components/validators/ValidationResults.tsx
@@ -127,17 +127,13 @@ function ValidationSuccess({
         <CheckCircle2 className="w-5 h-5 text-green-600 dark:text-green-500 flex-shrink-0 mt-0.5" />
         <div>
           <h3 className="font-semibold text-green-600 dark:text-green-500 mb-1">
-            Valid!
+            Looking good!
           </h3>
-          {metadata && (
-            <ul className="text-sm text-muted-foreground space-y-1">
-              {Object.entries(metadata).map(([key, value]) => (
-                <li key={key}>
-                  {key}: {String(value)}
-                </li>
-              ))}
-            </ul>
-          )}
+          <p className="text-sm text-muted-foreground">
+            {metadata?.toolName
+              ? `Your ${metadata.toolName} is valid.`
+              : "No errors found."}
+          </p>
         </div>
       </div>
     </div>

--- a/apps/codemata/lib/tools-data.ts
+++ b/apps/codemata/lib/tools-data.ts
@@ -41,6 +41,7 @@ import {
   minifyTypescript,
   minifyXml,
 } from "../app/minifiers/actions";
+import { validateHtml } from "../app/validators/actions";
 import type {
   EncoderTool,
   FormatterTool,
@@ -692,7 +693,7 @@ export const VALIDATOR_TOOLS: Record<string, ValidatorTool> = {
     description: "Validate HTML syntax and check for accessibility issues",
     url: "/validators/html-validator",
     icon: Code,
-    comingSoon: true,
+    comingSoon: false,
     language: "html",
     keywords: [
       "html",
@@ -705,6 +706,7 @@ export const VALIDATOR_TOOLS: Record<string, ValidatorTool> = {
       "a11y",
     ],
     example: "",
+    action: validateHtml,
     metadata: {
       title: "HTML Validator | Codemata",
       description:

--- a/apps/codemata/lib/types.ts
+++ b/apps/codemata/lib/types.ts
@@ -1,4 +1,5 @@
 import type { LucideIcon } from "lucide-react";
+import type { ValidationResult } from "./validators/types";
 
 export type Indentation = "two-spaces" | "four-spaces" | "tabs";
 
@@ -141,10 +142,18 @@ export interface EncoderTool extends Tool {
 }
 
 /**
- * Validator Tool interface (no action yet - Phase 9.1 scaffolding only)
+ * Validator Tool interface
  */
 export interface ValidatorTool extends Tool {
-  action?: never; // No action in Phase 9.1
+  action?: ValidatorAction;
   example: string;
   language: "json" | "html" | "css" | "xml" | "text";
 }
+
+/**
+ * Validator action type
+ */
+export type ValidatorAction = (
+  input: string,
+  options?: Record<string, unknown>,
+) => Promise<ValidationResult>;

--- a/apps/codemata/lib/validators/examples.ts
+++ b/apps/codemata/lib/validators/examples.ts
@@ -27,11 +27,10 @@ export const VALIDATOR_EXAMPLES = {
 <html>
   <head><title>Test Page</title>
   <body>
-    <div>
-      <p>Unclosed paragraph
-      <span>Mismatched nesting</div>
-    </span>
-  </body>`,
+    <img src="test.jpg">
+    <p>Unclosed paragraph
+  </body>
+</html>`,
 
   css: `.container {
   color: #ff0000;

--- a/apps/codemata/specs/phase-9-validators.md
+++ b/apps/codemata/specs/phase-9-validators.md
@@ -1256,7 +1256,18 @@ function MatchDetails({ match, index }: { match: RegexMatch; index: number }) {
 
 ---
 
-### Phase 9.4: HTML Validator (Day 7-8)
+### Phase 9.4: HTML Validator (Day 7-8) ✅ **COMPLETE**
+
+**Completed:** January 25, 2026
+
+**Key Features Implemented:**
+- html-validate with recommended preset
+- Severity mapping (2→errors, 1→warnings)
+- 65/35 horizontal layout (desktop), stacked (mobile)
+- Conditional layout (full-width before validation, split after)
+- Simplified success messages ("Looking good! Your HTML is valid.")
+- Sticky results panel on desktop
+- Full test coverage (28 passing tests)
 
 #### Server Action
 

--- a/apps/codemata/tests/e2e/components/transformer-validator.spec.ts
+++ b/apps/codemata/tests/e2e/components/transformer-validator.spec.ts
@@ -53,12 +53,8 @@ test.describe("JSON Validator Component", () => {
     await validateButton.click();
 
     // Wait for success message to appear
-    const successText = page.locator("text=Valid!");
+    const successText = page.locator("text=/Looking good.*valid/i");
     await expect(successText).toBeVisible();
-
-    // Should show metadata
-    const metadataText = page.locator("text=/Type:/i");
-    await expect(metadataText).toBeVisible();
   });
 
   test("expands and collapses schema editor", async ({ page }) => {
@@ -120,28 +116,6 @@ test.describe("JSON Validator Component", () => {
     // Error should mention required field (select from error button, not schema editor)
     const errorButton = page.locator('button[aria-label*="Error at line"]');
     await expect(errorButton).toContainText(/required.*name/i);
-  });
-
-  test("displays metadata for valid JSON", async ({ page }) => {
-    // Enter valid JSON object (first CodeMirror on page)
-    const inputEditor = page.locator(".cm-content").first();
-    await inputEditor.click();
-    await inputEditor.fill('{"name": "test", "items": [1, 2, 3]}');
-
-    // Click validate button
-    const validateButton = page.locator('button:has-text("Validate JSON")');
-    await validateButton.click();
-
-    // Wait for success message to appear
-    const successText = page.locator("text=Valid!");
-    await expect(successText).toBeVisible();
-
-    // Should show metadata (properties count and type)
-    const typeText = page.locator("text=/Type:.*object/i");
-    await expect(typeText).toBeVisible();
-
-    const propertiesText = page.locator("text=/Properties:.*2/i");
-    await expect(propertiesText).toBeVisible();
   });
 
   test("scrolls to error when clicking error message", async ({ page }) => {


### PR DESCRIPTION
Add html-validate integration and refactor validator layouts for better space utilization and user experience.

**New Features:**
- HTML Validator with html-validate library (recommended preset)
- Structural + accessibility validation (WCAG checks included)
- 8 comprehensive unit tests covering valid/invalid HTML scenarios

**UX Improvements:**
- Horizontal 65/35 layout for desktop (editor/results split)
- Dynamic layout: full-width pre-validation, split post-validation
- Validate button positioned under editor (left column)
- Sticky results panel on desktop for easier reference
- Applied new layout pattern to both HTML & JSON validators

**Refactoring:**
- Simplified success messages: "Looking good! Your {tool} is valid."
- Removed metadata display (character count, line count) from success
- Cleaned up unused calculateMetadata function
- Updated ValidatorTool type to support action functions

**Testing:**
- All 124 tests passing (28 validator tests)
- Type checking clean
- Linting passing
- Tests validate structure without assuming library-specific errors

**Files Changed:**
- components/validators/HtmlValidator.tsx (new)
- components/validators/JsonValidator.tsx (layout refactor)
- components/validators/ValidationResults.tsx (simplified success)
- app/validators/actions.ts (validateHtml, cleanup)
- lib/tools-data.ts (enabled HTML validator)
- lib/validators/examples.ts (broken HTML sample)
- __tests__/validators.test.ts (8 new HTML tests)

Closes Phase 9.4 - HTML Validator
Progress: Phase 9.1-9.4 complete (JSON & HTML validators live)