### PR TITLE
feat(validators): add XML Validator with fast-xml-parser

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -37,8 +37,8 @@ Tools App is a suite of three web applications providing free, high-quality deve
    - Code formatters (8 languages/formats)
    - Code minifiers (6 languages/formats)
    - Encoders/decoders (5 tools: JWT, Base64, URL, HTML Entity, JS String)
-   - Validators (3 tools: JSON, HTML, CSS) - **NEW**
-   - Future: More validators, viewers, generators, converters
+   - Validators (4 tools: JSON, HTML, CSS, XML) - **NEW**
+   - Future: Regex Tester, URL Validator, more validators, viewers, generators, converters
 
 2. **Moni** (moni.benmvp.com) - Financial calculators and planning tools
 

--- a/TODO.md
+++ b/TODO.md
@@ -41,7 +41,7 @@ Examples
 - [x] JSON (`JSON.parse()` for basic validation, `ajv` for schema validation) - HIGH VALUE ✅
 - [x] HTML (`html-validate`) ✅
 - [x] CSS (`css-tree` for strict syntax validation) ✅
-- [ ] XML (`xml2js`, potentially a schema validator)
+- [x] XML (`fast-xml-parser` for well-formedness validation) ✅
 - [ ] Regex Tester (Potentially a library for visual representation of matches) - HIGH TRAFFIC
 - [ ] Favicon (Fetch favicon using a Server Action, parse HTML for `<link rel="icon">`, check image format, size, etc.)
 - [ ] SEO (Libraries/APIs for analyzing meta tags, etc.)

--- a/apps/codemata/app/validators/[slug]/page.tsx
+++ b/apps/codemata/app/validators/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { CategoryBackLink } from "@/components/CategoryBackLink";
 import { CssValidator } from "@/components/validators/CssValidator";
 import { HtmlValidator } from "@/components/validators/HtmlValidator";
 import { JsonValidator } from "@/components/validators/JsonValidator";
+import { XmlValidator } from "@/components/validators/XmlValidator";
 import { VALIDATOR_TOOLS } from "@/lib/tools-data";
 import { VALIDATOR_EXAMPLES } from "@/lib/validators/examples";
 
@@ -102,6 +103,22 @@ export default async function ValidatorPage({
             <p className="text-muted-foreground text-lg">{tool.description}</p>
           </div>
           <CssValidator example={VALIDATOR_EXAMPLES.css} />
+        </div>
+      </div>
+    );
+  }
+
+  // XML Validator
+  if (slug === "xml-validator") {
+    return (
+      <div className="max-w-7xl mx-auto px-4 py-6 md:py-12">
+        <div className="flex flex-col gap-6">
+          <CategoryBackLink href="/validators" label="Validators" />
+          <div>
+            <h1 className="text-3xl md:text-4xl font-bold mb-2">{tool.name}</h1>
+            <p className="text-muted-foreground text-lg">{tool.description}</p>
+          </div>
+          <XmlValidator example={VALIDATOR_EXAMPLES.xml} />
         </div>
       </div>
     );

--- a/apps/codemata/components/validators/XmlValidator.tsx
+++ b/apps/codemata/components/validators/XmlValidator.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import type { EditorView } from "@codemirror/view";
+import { useMemo, useState } from "react";
+import { validateXml } from "@/app/validators/actions";
+import { CodeEditor } from "@/components/CodeEditor";
+import { Button } from "@/components/ui/button";
+import { createLinter, scrollToError } from "@/lib/validators/diagnostics";
+import type { ValidationError, ValidationResult } from "@/lib/validators/types";
+import { ValidationResults } from "./ValidationResults";
+
+interface XmlValidatorProps {
+  example: string;
+}
+
+export function XmlValidator({ example }: XmlValidatorProps) {
+  const [input, setInput] = useState(example);
+  const [result, setResult] = useState<ValidationResult | null>(null);
+  const [isValidating, setIsValidating] = useState(false);
+  const [editorView, setEditorView] = useState<EditorView | null>(null);
+
+  const handleValidate = async () => {
+    setIsValidating(true);
+    try {
+      const validationResult = await validateXml(input);
+      setResult(validationResult);
+    } catch (error) {
+      console.error("Validation failed:", error);
+      setResult({
+        valid: false,
+        errors: [
+          {
+            line: 1,
+            column: 1,
+            message: "Validation failed. Please try again.",
+            severity: "error",
+          },
+        ],
+        warnings: [],
+      });
+    } finally {
+      setIsValidating(false);
+    }
+  };
+
+  const handleErrorClick = (error: ValidationError) => {
+    if (editorView) {
+      scrollToError(editorView, error.line, error.column);
+    }
+  };
+
+  // Memoize extensions to prevent unnecessary CodeMirror reconfiguration
+  const editorExtensions = useMemo(() => {
+    return result ? [createLinter([...result.errors, ...result.warnings])] : [];
+  }, [result]);
+
+  return (
+    <div
+      className={
+        result ? "grid grid-cols-1 lg:grid-cols-[65fr_35fr] gap-4" : ""
+      }
+    >
+      {/* Left Column: Editor + Button */}
+      <div className="space-y-4">
+        <CodeEditor
+          value={input}
+          onChange={setInput}
+          language="xml"
+          extensions={editorExtensions}
+          onViewUpdate={setEditorView}
+          label="XML Input"
+        />
+
+        {/* Validate Button */}
+        <div className="flex gap-2">
+          <Button
+            onClick={handleValidate}
+            disabled={!input.trim() || isValidating}
+            className="w-full sm:w-auto"
+            size="default"
+          >
+            {isValidating ? "Validating..." : "Validate XML"}
+          </Button>
+        </div>
+      </div>
+
+      {/* Right Column: Results */}
+      {result && (
+        <div className="lg:sticky lg:top-4 lg:self-start">
+          <ValidationResults result={result} onErrorClick={handleErrorClick} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/codemata/css-tree.d.ts
+++ b/apps/codemata/css-tree.d.ts
@@ -14,5 +14,10 @@ declare module "css-tree" {
     onParseError?: (error: ParseError) => void;
   }
 
-  export function parse(input: string, options?: ParseOptions): any;
+  export interface CssNode {
+    type: string;
+    [key: string]: unknown;
+  }
+
+  export function parse(input: string, options?: ParseOptions): CssNode;
 }

--- a/apps/codemata/lib/tools-data.ts
+++ b/apps/codemata/lib/tools-data.ts
@@ -41,13 +41,18 @@ import {
   minifyTypescript,
   minifyXml,
 } from "../app/minifiers/actions";
-import { validateCss, validateHtml } from "../app/validators/actions";
+import {
+  validateCss,
+  validateHtml,
+  validateXml,
+} from "../app/validators/actions";
 import type {
   EncoderTool,
   FormatterTool,
   MinifierTool,
   ValidatorTool,
 } from "./types";
+import { VALIDATOR_EXAMPLES } from "./validators/examples";
 
 /**
  * Formatter Tools - Record-based structure for O(1) lookups
@@ -736,7 +741,8 @@ export const VALIDATOR_TOOLS: Record<string, ValidatorTool> = {
     description: "Validate XML structure and check for well-formedness",
     url: "/validators/xml-validator",
     icon: FileX,
-    comingSoon: true,
+    comingSoon: false,
+    action: validateXml,
     language: "xml",
     keywords: [
       "xml",
@@ -747,7 +753,7 @@ export const VALIDATOR_TOOLS: Record<string, ValidatorTool> = {
       "well-formed",
       "lint",
     ],
-    example: "",
+    example: VALIDATOR_EXAMPLES.xml,
     metadata: {
       title: "XML Validator | Codemata",
       description:

--- a/apps/codemata/lib/validators/examples.ts
+++ b/apps/codemata/lib/validators/examples.ts
@@ -46,10 +46,7 @@ export const VALIDATOR_EXAMPLES = {
   xml: `<?xml version="1.0" encoding="UTF-8"?>
 <root>
   <item id="1">First Item</item>
-  <item id="2">
-    <name>Second Item
-    <value>Missing closing tag
-  </item>
+  <item id="2">Second Item</item>
   <mismatched></wrong>
 </root>`,
 

--- a/apps/codemata/package.json
+++ b/apps/codemata/package.json
@@ -50,6 +50,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "css-tree": "^3.1.0",
+    "fast-xml-parser": "^5.3.3",
     "html-minifier-terser": "^7.2.0",
     "html-validate": "^10.6.0",
     "json-source-map": "^0.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       css-tree:
         specifier: ^3.1.0
         version: 3.1.0
+      fast-xml-parser:
+        specifier: ^5.3.3
+        version: 5.3.3
       html-minifier-terser:
         specifier: ^7.2.0
         version: 7.2.0
@@ -2471,6 +2474,10 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-parser@5.3.3:
+    resolution: {integrity: sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA==}
+    hasBin: true
+
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
 
@@ -3752,6 +3759,9 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
@@ -6411,6 +6421,10 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fast-xml-parser@5.3.3:
+    dependencies:
+      strnum: 2.1.2
+
   fault@1.0.4:
     dependencies:
       format: 0.2.2
@@ -8055,6 +8069,8 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strnum@2.1.2: {}
 
   style-mod@4.1.3: {}
 


### PR DESCRIPTION
Implements Phase 9.6 - XML structural validation with IDE-like UX

Features:
- Server action using fast-xml-parser for accurate line/column errors
- User-friendly error messages ("Mismatched tag: expected </item>, found </wrong>")
- XmlValidator component with 65/35 responsive layout
- Inline error highlighting via CodeMirror lint extension
- Click-to-scroll error navigation
- Minimal success state ("Valid XML")

Implementation:
- Added validateXml() in app/validators/actions.ts
- Created XmlValidator.tsx component following HtmlValidator pattern
- Updated xml-validator in tools-data.ts (comingSoon: false)
- Added route handler in app/validators/[slug]/page.tsx
- Updated VALIDATOR_EXAMPLES.xml to single mismatched tag error

Testing:
- 21 comprehensive unit tests (valid XML, structural errors, edge cases)
- All 61 validator tests pass (JSON: 20, HTML: 8, CSS: 12, XML: 21)
- E2E tests pass (shared ValidationResults component)
- Type checking, linting, formatting all pass

Fixes:
- Fixed css-tree.d.ts lint warning (any -> CssNode)

Docs:
- Updated SPEC.md (22 tools, 4 validators)
- Updated TODO.md (marked XML complete)
- Updated phase-9-validators.md (Phase 9.6 complete)

Tool is production-ready at /validators/xml-validator