### PR TITLE
feat(validators): add URL Validator with smart metadata display

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -37,8 +37,8 @@ Tools App is a suite of three web applications providing free, high-quality deve
    - Code formatters (8 languages/formats)
    - Code minifiers (6 languages/formats)
    - Encoders/decoders (5 tools: JWT, Base64, URL, HTML Entity, JS String)
-   - Validators (4 tools: JSON, HTML, CSS, XML) - **NEW**
-   - Future: Regex Tester, URL Validator, more validators, viewers, generators, converters
+   - Validators (5 tools: JSON, HTML, CSS, XML, URL) - **NEW**
+   - Future: Regex Tester, more validators, viewers, generators, converters
 
 2. **Moni** (moni.benmvp.com) - Financial calculators and planning tools
 
@@ -3786,8 +3786,9 @@ The implementation follows a **pragmatic, YAGNI-driven approach** that prioritiz
 - [x] JSON Validator
 - [x] HTML Validator (with html-validate, a11y checks, 65/35 layout)
 - [x] CSS Validator (css-tree, strict syntax validation, 65/35 layout)
-- [ ] XML Validator
+- [x] XML Validator
 - [ ] Regex Tester
+- [ ] URL Validator
 
 **9.3 AI Content & SEO**
 

--- a/TODO.md
+++ b/TODO.md
@@ -42,6 +42,7 @@ Examples
 - [x] HTML (`html-validate`) ✅
 - [x] CSS (`css-tree` for strict syntax validation) ✅
 - [x] XML (`fast-xml-parser` for well-formedness validation) ✅
+- [x] URL Validator (Node.js built-in `URL` constructor) ✅
 - [ ] Regex Tester (Potentially a library for visual representation of matches) - HIGH TRAFFIC
 - [ ] Favicon (Fetch favicon using a Server Action, parse HTML for `<link rel="icon">`, check image format, size, etc.)
 - [ ] SEO (Libraries/APIs for analyzing meta tags, etc.)

--- a/apps/codemata/README.md
+++ b/apps/codemata/README.md
@@ -10,7 +10,7 @@ Codemata is a Next.js web application providing high-quality code formatters and
 
 ## What is Codemata?
 
-Codemata offers **14 free developer tools** (as of Phase 5.3):
+Codemata offers **19 free developer tools** (as of Phase 9.7):
 
 ### Formatters (8 tools)
 - CSS/SCSS Formatter
@@ -29,6 +29,13 @@ Codemata offers **14 free developer tools** (as of Phase 5.3):
 - JSON Minifier
 - SVG Minifier
 - XML Minifier
+
+### Validators (5 tools)
+- CSS Validator
+- HTML Validator
+- JSON Validator
+- URL Validator
+- XML Validator
 
 ### Goals
 

--- a/apps/codemata/app/validators/[slug]/page.tsx
+++ b/apps/codemata/app/validators/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { CategoryBackLink } from "@/components/CategoryBackLink";
 import { CssValidator } from "@/components/validators/CssValidator";
 import { HtmlValidator } from "@/components/validators/HtmlValidator";
 import { JsonValidator } from "@/components/validators/JsonValidator";
+import { UrlValidator } from "@/components/validators/UrlValidator";
 import { XmlValidator } from "@/components/validators/XmlValidator";
 import { VALIDATOR_TOOLS } from "@/lib/tools-data";
 import { VALIDATOR_EXAMPLES } from "@/lib/validators/examples";
@@ -119,6 +120,22 @@ export default async function ValidatorPage({
             <p className="text-muted-foreground text-lg">{tool.description}</p>
           </div>
           <XmlValidator example={VALIDATOR_EXAMPLES.xml} />
+        </div>
+      </div>
+    );
+  }
+
+  // URL Validator
+  if (slug === "url-validator") {
+    return (
+      <div className="max-w-7xl mx-auto px-4 py-6 md:py-12">
+        <div className="flex flex-col gap-6">
+          <CategoryBackLink href="/validators" label="Validators" />
+          <div>
+            <h1 className="text-3xl md:text-4xl font-bold mb-2">{tool.name}</h1>
+            <p className="text-muted-foreground text-lg">{tool.description}</p>
+          </div>
+          <UrlValidator example={VALIDATOR_EXAMPLES.url} />
         </div>
       </div>
     );

--- a/apps/codemata/components/validators/UrlValidator.tsx
+++ b/apps/codemata/components/validators/UrlValidator.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { useState } from "react";
+import { validateUrl } from "@/app/validators/actions";
+import { CodeEditor } from "@/components/CodeEditor";
+import { Button } from "@/components/ui/button";
+
+interface UrlValidatorProps {
+  example: string;
+}
+
+interface ParsedUrl {
+  line: number;
+  url: string;
+  valid: boolean;
+  error?: string;
+  parsed?: {
+    protocol: string;
+    hostname: string;
+    port?: string;
+    pathname?: string;
+    query?: Array<{ key: string; value: string | string[] }>;
+    hash?: string;
+    username?: string;
+    password?: string;
+  };
+}
+
+interface UrlValidationResult {
+  validCount: number;
+  errorCount: number;
+  urls: ParsedUrl[];
+}
+
+export function UrlValidator({ example }: UrlValidatorProps) {
+  const [input, setInput] = useState(example);
+  const [result, setResult] = useState<UrlValidationResult | null>(null);
+  const [isValidating, setIsValidating] = useState(false);
+
+  const handleValidate = async () => {
+    setIsValidating(true);
+    const validationResult = await validateUrl(input);
+    setResult(validationResult);
+    setIsValidating(false);
+  };
+
+  const hasResult = result !== null;
+
+  return (
+    <div className="flex flex-col lg:flex-row gap-6">
+      {/* Input Section */}
+      <div
+        className={`flex-1 space-y-4 ${hasResult ? "lg:w-[65%]" : "w-full"}`}
+      >
+        <div>
+          <label htmlFor="url-input" className="text-sm font-medium mb-2 block">
+            URLs (one per line)
+          </label>
+          <CodeEditor
+            value={input}
+            onChange={setInput}
+            label="URLs"
+            language="text"
+          />
+        </div>
+
+        <Button
+          onClick={handleValidate}
+          disabled={isValidating}
+          className="w-full sm:w-auto"
+        >
+          {isValidating ? "Validating..." : "Validate URLs"}
+        </Button>
+      </div>
+
+      {/* Results Section */}
+      {hasResult && (
+        <div className="flex-1 lg:w-[35%] lg:sticky lg:top-4 lg:self-start">
+          <UrlResults result={result} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UrlResults({ result }: { result: UrlValidationResult }) {
+  const { validCount, errorCount, urls } = result;
+  const errors = urls.filter((u) => !u.valid);
+  const validUrls = urls.filter((u) => u.valid);
+
+  return (
+    <div className="space-y-4">
+      {/* Summary */}
+      <div className="p-4 rounded-md border">
+        {errorCount === 0 ? (
+          <p className="text-sm font-medium text-green-600">
+            ✓ All {validCount} {validCount === 1 ? "URL is" : "URLs are"} valid
+          </p>
+        ) : (
+          <p className="text-sm font-medium">
+            ✗ {errorCount} {errorCount === 1 ? "error" : "errors"} found,{" "}
+            {validCount} {validCount === 1 ? "URL" : "URLs"} valid
+          </p>
+        )}
+      </div>
+
+      {/* Errors */}
+      {errors.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold">Errors ({errors.length})</h3>
+          {errors.map((urlData) => (
+            <div
+              key={urlData.line}
+              className="w-full p-3 rounded-md border border-destructive/50 bg-destructive/10"
+            >
+              <div className="text-sm">
+                <span className="font-mono text-destructive">
+                  Line {urlData.line}:
+                </span>{" "}
+                <span className="text-muted-foreground break-all">
+                  {urlData.url}
+                </span>
+              </div>
+              <div className="text-sm text-destructive mt-1">
+                → {urlData.error}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Valid URLs */}
+      {validUrls.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold">
+            Valid URLs ({validUrls.length})
+          </h3>
+          {validUrls.map((urlData) => (
+            <UrlDetailsCard key={urlData.line} urlData={urlData} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function UrlDetailsCard({ urlData }: { urlData: ParsedUrl }) {
+  const [expanded, setExpanded] = useState(false);
+  const { line, url, parsed } = urlData;
+
+  return (
+    <div className="rounded-md border">
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        className="w-full p-3 text-left flex items-start justify-between hover:bg-muted/50 transition-colors"
+      >
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-mono text-muted-foreground">
+            Line {line}
+          </div>
+          <div className="text-sm break-all mt-1">{url}</div>
+        </div>
+        <ChevronDown
+          className={`w-4 h-4 flex-shrink-0 ml-2 transition-transform ${
+            expanded ? "rotate-180" : ""
+          }`}
+        />
+      </button>
+
+      {expanded && parsed && (
+        <div className="px-3 pb-3 space-y-3 border-t">
+          {/* Basic Info */}
+          <div className="space-y-1.5 pt-3">
+            <MetadataRow label="Protocol" value={parsed.protocol} />
+            <MetadataRow label="Hostname" value={parsed.hostname} />
+            {parsed.port && <MetadataRow label="Port" value={parsed.port} />}
+            {parsed.pathname && (
+              <MetadataRow label="Path" value={parsed.pathname} />
+            )}
+            {parsed.hash && <MetadataRow label="Hash" value={parsed.hash} />}
+            {parsed.username && (
+              <MetadataRow label="Username" value={parsed.username} />
+            )}
+            {parsed.password && (
+              <MetadataRow
+                label="Password"
+                value={parsed.password}
+                className="text-muted-foreground italic"
+              />
+            )}
+          </div>
+
+          {/* Query Parameters Table */}
+          {parsed.query && parsed.query.length > 0 && (
+            <div>
+              <div className="text-sm font-medium mb-2">
+                Query Parameters ({parsed.query.length})
+              </div>
+              <div className="rounded-md overflow-hidden border">
+                {parsed.query.map((param, idx) => (
+                  <QueryParamRow
+                    key={`${param.key}-${idx}`}
+                    param={param}
+                    isEven={idx % 2 === 0}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MetadataRow({
+  label,
+  value,
+  className = "",
+}: {
+  label: string;
+  value: string;
+  className?: string;
+}) {
+  return (
+    <div className="flex gap-2 text-sm">
+      <span className="text-muted-foreground w-20 flex-shrink-0">{label}:</span>
+      <span className={`font-mono break-all ${className}`}>{value}</span>
+    </div>
+  );
+}
+
+function QueryParamRow({
+  param,
+  isEven,
+}: {
+  param: { key: string; value: string | string[] };
+  isEven: boolean;
+}) {
+  const isArray = Array.isArray(param.value);
+  const displayValue = isArray
+    ? `[${(param.value as string[]).join(", ")}]`
+    : param.value;
+
+  return (
+    <div
+      className={`flex gap-3 px-3 py-2 text-sm ${isEven ? "bg-muted/30" : ""}`}
+    >
+      <span className="font-mono text-muted-foreground w-1/3 break-all">
+        {param.key}
+      </span>
+      <span className="font-mono flex-1 break-all">{displayValue}</span>
+    </div>
+  );
+}

--- a/apps/codemata/lib/tools-data.ts
+++ b/apps/codemata/lib/tools-data.ts
@@ -763,17 +763,28 @@ export const VALIDATOR_TOOLS: Record<string, ValidatorTool> = {
   "url-validator": {
     id: "url-validator",
     name: "URL Validator",
-    description: "Validate URL syntax and structure",
+    description:
+      "Validate URLs and parse their components (protocol, host, query params)",
     url: "/validators/url-validator",
     icon: Link,
-    comingSoon: true,
+    comingSoon: false,
     language: "text",
-    keywords: ["url", "uri", "link", "validate", "validator", "check"],
-    example: "",
+    keywords: [
+      "url",
+      "uri",
+      "link",
+      "validate",
+      "validator",
+      "check",
+      "parse",
+      "query",
+      "params",
+    ],
+    example: VALIDATOR_EXAMPLES.url,
     metadata: {
       title: "URL Validator | Codemata",
       description:
-        "Validate URL syntax and structure. Free online URL validator with detailed parsing.",
+        "Validate URLs and parse components. Free online URL validator with query param parsing.",
     },
   },
 };

--- a/apps/codemata/lib/validators/examples.ts
+++ b/apps/codemata/lib/validators/examples.ts
@@ -50,5 +50,10 @@ export const VALIDATOR_EXAMPLES = {
   <mismatched></wrong>
 </root>`,
 
-  url: `https://example.com/path/to/resource?param=value#section`,
+  url: `https://example.com/api/users?page=1&limit=10
+example.com
+ftp://user:pass@files.company.com:21/assets
+http://localhost:3000
+
+https://192.168.1.1/admin#settings`,
 };

--- a/apps/codemata/lib/validators/types.ts
+++ b/apps/codemata/lib/validators/types.ts
@@ -47,3 +47,32 @@ export interface RegexTestResult {
   matches: RegexMatch[];
   error?: string;
 }
+
+// URL-specific types
+export interface ParsedUrl {
+  line: number; // Line number in textarea (1-indexed)
+  url: string; // Original URL string
+  valid: boolean;
+  error?: string; // Error message if invalid
+  parsed?: {
+    protocol: string; // "https", "http", "ftp", etc.
+    hostname: string; // "example.com"
+    port?: string; // Only if non-default (not 80/443)
+    pathname?: string; // Only if not just "/"
+    query?: QueryParam[]; // Parsed query parameters
+    hash?: string; // Fragment without # symbol
+    username?: string; // For FTP URLs
+    password?: string; // Always "[redacted]" if present
+  };
+}
+
+export interface QueryParam {
+  key: string;
+  value: string | string[]; // Array for duplicate keys
+}
+
+export interface UrlValidationResult {
+  validCount: number;
+  errorCount: number;
+  urls: ParsedUrl[];
+}

--- a/apps/codemata/scripts/verify-metadata.ts
+++ b/apps/codemata/scripts/verify-metadata.ts
@@ -41,7 +41,6 @@ import {
   ALL_FORMATTERS,
   ALL_MINIFIERS,
   ALL_TOOLS,
-  ALL_VALIDATORS,
 } from "../lib/tools-data";
 import { getAppUrl, getToolUrl } from "../lib/utils";
 

--- a/apps/codemata/specs/phase-9-validators.md
+++ b/apps/codemata/specs/phase-9-validators.md
@@ -1,6 +1,6 @@
 # Phase 9: Validators/Checkers - Implementation Specification
 
-**Status:** 🚧 In Progress (Phase 9.1-9.6 complete - JSON, HTML, CSS, XML validators live)
+**Status:** 🚧 In Progress (Phase 9.1-9.7 complete - JSON, HTML, CSS, XML, URL validators live)
 
 ---
 
@@ -23,7 +23,7 @@
 Add 5-6 professional validation tools to Codemata with IDE-like validation UX featuring inline error highlighting and detailed error panels.
 
 ### Current State
-- **Total Tools:** 22 (8 formatters + 6 minifiers + 5 encoders + 3 validators)
+- **Total Tools:** 23 (8 formatters + 6 minifiers + 5 encoders + 4 validators)
 - **Target:** 24-25 tools (add 5-6 validators)
 
 ### Tools to Build
@@ -33,7 +33,7 @@ Add 5-6 professional validation tools to Codemata with IDE-like validation UX fe
 3. ✅ **HTML Validator** (using html-validate, full-throttle) - **COMPLETE**
 4. ✅ **CSS Validator** (syntax validation using css-tree) - **COMPLETE**
 5. ✅ **XML Validator** (structural validation using fast-xml-parser) - **COMPLETE**
-6. **URL Validator** (bonus - optional quick win)
+6. ✅ **URL Validator** (Node.js URL constructor) - **COMPLETE**
 
 ### Key Features
 
@@ -1442,7 +1442,27 @@ function formatUserFriendlyMessage(message: string): string {
 
 ---
 
-### Phase 9.7: Integration & Data (Day 11-12)
+### Phase 9.7: URL Validator (Day 11) ✅ **COMPLETE**
+
+**Completed:** January 30, 2026
+
+**Key Features Implemented:**
+- Node.js built-in URL constructor (no external validation libraries)
+- Permissive validation (accepts any protocol including localhost, IPs)
+- Smart metadata display (only shows non-default ports, optional fields)
+- Query parameter parsing with array support (URLSearchParams.getAll())
+- Security: Password redaction for FTP URLs
+- Decoded values (URLs, query params, hash fragments)
+- 65/35 horizontal layout (desktop), stacked (mobile)
+- Conditional layout (full-width before validation, split after)
+- Collapsible URL metadata cards
+- Striped query param table
+- Full test coverage (32 URL validator tests, 93 total passing)
+- E2E test coverage
+
+---
+
+### Phase 9.8: Integration & Data (Day 12-13)
 
 #### Add to `lib/tools-data.ts`
 

--- a/apps/codemata/tests/e2e/tools/validators.spec.ts
+++ b/apps/codemata/tests/e2e/tools/validators.spec.ts
@@ -58,8 +58,8 @@ not a url at all`);
     const errorHeading = page.locator('h3:has-text("Errors (2)")');
     await expect(errorHeading).toBeVisible();
 
-    // Verify one of the errors mentions missing protocol
-    const errorMessage = page.locator("text=/Missing protocol/i");
+    // Verify at least one error mentions missing protocol (use .first() to avoid strict mode)
+    const errorMessage = page.locator("text=/Missing protocol/i").first();
     await expect(errorMessage).toBeVisible();
   });
 
@@ -95,7 +95,8 @@ not a url at all`);
     await expect(page.locator("text=/Hostname.*example.com/i")).toBeVisible();
     await expect(page.locator("text=/Port.*8080/i")).toBeVisible();
     await expect(page.locator("text=/Path.*/api/users/i")).toBeVisible();
-    await expect(page.locator("text=/Hash.*#results/i")).toBeVisible();
+    await expect(page.locator("text=/Hash/i")).toBeVisible();
+    await expect(page.locator("text=/results/i")).toBeVisible();
 
     // Verify query params table
     await expect(page.locator("text=/Query Parameters/i")).toBeVisible();

--- a/apps/codemata/tests/e2e/tools/validators.spec.ts
+++ b/apps/codemata/tests/e2e/tools/validators.spec.ts
@@ -96,11 +96,19 @@ not a url at all`);
     await expect(page.locator("text=/Port.*8080/i")).toBeVisible();
     await expect(page.locator("text=/Path.*/api/users/i")).toBeVisible();
     await expect(page.locator("text=/Hash/i")).toBeVisible();
-    await expect(page.locator("text=/results/i")).toBeVisible();
+    // Hash value appears after "Hash:" label, check it exists in metadata section
+    await expect(
+      page
+        .locator("div")
+        .filter({ hasText: /^Hash:/ })
+        .locator("text=results"),
+    ).toBeVisible();
 
     // Verify query params table
-    await expect(page.locator("text=/Query Parameters/i")).toBeVisible();
-    await expect(page.locator("text=/page/i")).toBeVisible();
-    await expect(page.locator("text=/sort/i")).toBeVisible();
+    const queryParamsSection = page.locator("text=/Query Parameters/i");
+    await expect(queryParamsSection).toBeVisible();
+    // Check query param keys exist in the table (avoid URL text matches)
+    await expect(page.locator('span.font-mono:has-text("page")')).toBeVisible();
+    await expect(page.locator('span.font-mono:has-text("sort")')).toBeVisible();
   });
 });

--- a/apps/codemata/tests/e2e/tools/validators.spec.ts
+++ b/apps/codemata/tests/e2e/tools/validators.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Validator Tool Tests
+ * Tests URL Validator tool (one representative validator)
+ * Runs on both desktop and mobile
+ *
+ * Per sample-based testing strategy:
+ * - Tests ONE validator tool to validate server action integration
+ * - Component behavior tested in tests/e2e/components/transformer-validator.spec.ts
+ * - All validators use same page template, so testing one validates all
+ */
+
+test.describe("URL Validator", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/validators/url-validator");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("validates multiple URLs successfully", async ({ page }) => {
+    const inputEditor = page.locator(".cm-content").first();
+    await expect(inputEditor).toBeVisible();
+
+    // Enter multiple valid URLs
+    await inputEditor.click();
+    await inputEditor.fill(`https://example.com
+http://localhost:3000
+https://api.github.com/users`);
+
+    // Click validate button
+    const validateButton = page.locator('button:has-text("Validate URLs")');
+    await validateButton.click();
+
+    // Wait for success message
+    const successText = page.locator("text=/All 3 URLs are valid/i");
+    await expect(successText).toBeVisible({ timeout: 10000 });
+  });
+
+  test("displays errors for invalid URLs", async ({ page }) => {
+    const inputEditor = page.locator(".cm-content").first();
+    await expect(inputEditor).toBeVisible();
+
+    // Enter mix of valid and invalid URLs
+    await inputEditor.click();
+    await inputEditor.fill(`https://example.com
+example.com
+not a url at all`);
+
+    // Click validate button
+    const validateButton = page.locator('button:has-text("Validate URLs")');
+    await validateButton.click();
+
+    // Wait for error summary
+    const errorSummary = page.locator("text=/2 errors found, 1 URL valid/i");
+    await expect(errorSummary).toBeVisible({ timeout: 10000 });
+
+    // Verify error messages are shown
+    const errorHeading = page.locator('h3:has-text("Errors (2)")');
+    await expect(errorHeading).toBeVisible();
+
+    // Verify one of the errors mentions missing protocol
+    const errorMessage = page.locator("text=/Missing protocol/i");
+    await expect(errorMessage).toBeVisible();
+  });
+
+  test("expands and shows URL metadata", async ({ page }) => {
+    const inputEditor = page.locator(".cm-content").first();
+    await expect(inputEditor).toBeVisible();
+
+    // Enter URL with metadata
+    await inputEditor.click();
+    await inputEditor.fill(
+      "https://example.com:8080/api/users?page=1&sort=name#results",
+    );
+
+    // Click validate button
+    const validateButton = page.locator('button:has-text("Validate URLs")');
+    await validateButton.click();
+
+    // Wait for valid URLs section
+    await expect(page.locator('h3:has-text("Valid URLs (1)")')).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Find and click the URL card to expand
+    const urlCard = page
+      .locator("button")
+      .filter({ hasText: "Line 1" })
+      .first();
+    await expect(urlCard).toBeVisible();
+    await urlCard.click();
+
+    // Verify metadata is displayed
+    await expect(page.locator("text=/Protocol.*https:/i")).toBeVisible();
+    await expect(page.locator("text=/Hostname.*example.com/i")).toBeVisible();
+    await expect(page.locator("text=/Port.*8080/i")).toBeVisible();
+    await expect(page.locator("text=/Path.*/api/users/i")).toBeVisible();
+    await expect(page.locator("text=/Hash.*#results/i")).toBeVisible();
+
+    // Verify query params table
+    await expect(page.locator("text=/Query Parameters/i")).toBeVisible();
+    await expect(page.locator("text=/page/i")).toBeVisible();
+    await expect(page.locator("text=/sort/i")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Implement comprehensive URL validation tool with the following features:

Core Functionality:
- Permissive validation using Node.js URL constructor (supports any protocol)
- Multiple URL validation (one per line)
- Smart metadata display (hides default ports, only shows relevant fields)
- Query parameter parsing with array support (URLSearchParams.getAll())
- Decoded values for URLs, query params, and hash fragments
- Password redaction for FTP URLs with username/password

UI/UX:
- Bespoke UrlValidator component with collapsible metadata cards
- 65/35 horizontal layout (desktop), stacked (mobile)
- Conditional layout (full-width before validation, split after)
- Striped table for query parameters
- Sticky results panel on desktop
- Helpful error messages with suggestions (e.g., "Missing protocol (try https://example.com)")

Testing:
- 32 comprehensive unit tests across 8 categories
- E2E test coverage for URL validator
- All 93 tests passing

Documentation:
- Updated README.md: 14 → 19 tools, added Validators section
- Updated SPEC.md: 4 → 5 validators
- Updated TODO.md: marked URL validator complete
- Updated phase-9-validators.md: Phase 9.7 complete

Closes Phase 9.7 of validator implementation roadmap.