### PR TITLE
test(e2e): add generator component and integration tests

### DIFF
--- a/apps/codemata/tests/e2e/components/gitignore-generator.spec.ts
+++ b/apps/codemata/tests/e2e/components/gitignore-generator.spec.ts
@@ -24,8 +24,8 @@ test.describe("GitignoreGenerator Component", () => {
     });
     await expect(generateButton).toBeDisabled();
 
-    // Select a template (e.g., Node)
-    const nodeButton = page.getByRole("button", { name: "Node", exact: true });
+    // Select a template (e.g., Node.js)
+    const nodeButton = page.getByRole("button", { name: "Node.js" });
     await nodeButton.click();
 
     // Generate button should now be enabled
@@ -38,7 +38,10 @@ test.describe("GitignoreGenerator Component", () => {
     await page.goto(REPRESENTATIVE_TOOL);
 
     // Select first template
-    const nodeButton = page.getByRole("button", { name: "Node", exact: true });
+    const nodeButton = page.getByRole("button", {
+      name: "Node.js",
+      exact: true,
+    });
     await nodeButton.click();
 
     // Verify selected count shows 1
@@ -54,8 +57,11 @@ test.describe("GitignoreGenerator Component", () => {
     // Verify selected count shows 2
     await expect(page.locator("text=/Selected \\(2\\)/i")).toBeVisible();
 
-    // Deselect first template
-    await nodeButton.click();
+    // Deselect first template (click the badge remove button)
+    const removeNodeButton = page.getByRole("button", {
+      name: "Remove Node.js",
+    });
+    await removeNodeButton.click();
 
     // Verify selected count shows 1 again
     await expect(page.locator("text=/Selected \\(1\\)/i")).toBeVisible();
@@ -67,7 +73,7 @@ test.describe("GitignoreGenerator Component", () => {
     await page.goto(REPRESENTATIVE_TOOL);
 
     // Select a template
-    const nodeButton = page.getByRole("button", { name: "Node", exact: true });
+    const nodeButton = page.getByRole("button", { name: "Node.js" });
     await nodeButton.click();
 
     // Click generate
@@ -76,9 +82,8 @@ test.describe("GitignoreGenerator Component", () => {
     });
     await generateButton.click();
 
-    // Wait for generation to complete (success toast)
-    const toast = page.locator("[data-sonner-toast]").first();
-    await expect(toast).toBeVisible({ timeout: 5000 });
+    // Wait for generation to complete (button re-enabled)
+    await expect(generateButton).toBeEnabled({ timeout: 5000 });
 
     // Verify copy button is visible and enabled
     const copyButton = page.getByRole("button", {
@@ -92,7 +97,7 @@ test.describe("GitignoreGenerator Component", () => {
     await page.goto(REPRESENTATIVE_TOOL);
 
     // Select and generate
-    const nodeButton = page.getByRole("button", { name: "Node", exact: true });
+    const nodeButton = page.getByRole("button", { name: "Node.js" });
     await nodeButton.click();
 
     const generateButton = page.getByRole("button", {
@@ -100,9 +105,8 @@ test.describe("GitignoreGenerator Component", () => {
     });
     await generateButton.click();
 
-    // Wait for output
-    const toast = page.locator("[data-sonner-toast]").first();
-    await expect(toast).toBeVisible({ timeout: 5000 });
+    // Wait for generation to complete (button re-enabled)
+    await expect(generateButton).toBeEnabled({ timeout: 5000 });
 
     // Click clear button
     const clearButton = page.getByRole("button", { name: /clear/i });
@@ -131,8 +135,11 @@ test.describe("GitignoreGenerator Component", () => {
     });
     await expect(pythonButton).toBeVisible();
 
-    // Node button should NOT be visible
-    const nodeButton = page.getByRole("button", { name: "Node", exact: true });
+    // Node.js button should NOT be visible
+    const nodeButton = page.getByRole("button", {
+      name: "Node.js",
+      exact: true,
+    });
     await expect(nodeButton).not.toBeVisible();
   });
 });

--- a/apps/codemata/tests/e2e/components/gitignore-generator.spec.ts
+++ b/apps/codemata/tests/e2e/components/gitignore-generator.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * GitignoreGenerator Component Tests
+ *
+ * Tests shared behavior of the GitignoreGenerator component.
+ * Uses .gitignore Generator as the representative tool page.
+ * These tests validate component logic, not tool-specific functionality.
+ *
+ * NOTE: Runs on desktop only - component behavior is device-independent.
+ */
+
+test.describe("GitignoreGenerator Component", () => {
+  const REPRESENTATIVE_TOOL = "/generators/gitignore-generator";
+
+  test("should enable generate button when template selected", async ({
+    page,
+  }) => {
+    await page.goto(REPRESENTATIVE_TOOL);
+
+    // Generate button should be disabled initially
+    const generateButton = page.getByRole("button", {
+      name: /generate \.gitignore/i,
+    });
+    await expect(generateButton).toBeDisabled();
+
+    // Select a template (e.g., Node)
+    const nodeButton = page.getByRole("button", { name: "Node", exact: true });
+    await nodeButton.click();
+
+    // Generate button should now be enabled
+    await expect(generateButton).toBeEnabled();
+  });
+
+  test("should update selected count when templates toggled", async ({
+    page,
+  }) => {
+    await page.goto(REPRESENTATIVE_TOOL);
+
+    // Select first template
+    const nodeButton = page.getByRole("button", { name: "Node", exact: true });
+    await nodeButton.click();
+
+    // Verify selected count shows 1
+    await expect(page.locator("text=/Selected \\(1\\)/i")).toBeVisible();
+
+    // Select second template
+    const pythonButton = page.getByRole("button", {
+      name: "Python",
+      exact: true,
+    });
+    await pythonButton.click();
+
+    // Verify selected count shows 2
+    await expect(page.locator("text=/Selected \\(2\\)/i")).toBeVisible();
+
+    // Deselect first template
+    await nodeButton.click();
+
+    // Verify selected count shows 1 again
+    await expect(page.locator("text=/Selected \\(1\\)/i")).toBeVisible();
+  });
+
+  test("should show output and enable copy button after generation", async ({
+    page,
+  }) => {
+    await page.goto(REPRESENTATIVE_TOOL);
+
+    // Select a template
+    const nodeButton = page.getByRole("button", { name: "Node", exact: true });
+    await nodeButton.click();
+
+    // Click generate
+    const generateButton = page.getByRole("button", {
+      name: /generate \.gitignore/i,
+    });
+    await generateButton.click();
+
+    // Wait for generation to complete (success toast)
+    const toast = page.locator("[data-sonner-toast]").first();
+    await expect(toast).toBeVisible({ timeout: 5000 });
+
+    // Verify copy button is visible and enabled
+    const copyButton = page.getByRole("button", {
+      name: /copy to clipboard/i,
+    });
+    await expect(copyButton).toBeVisible();
+    await expect(copyButton).toBeEnabled();
+  });
+
+  test("should clear output when clear button clicked", async ({ page }) => {
+    await page.goto(REPRESENTATIVE_TOOL);
+
+    // Select and generate
+    const nodeButton = page.getByRole("button", { name: "Node", exact: true });
+    await nodeButton.click();
+
+    const generateButton = page.getByRole("button", {
+      name: /generate \.gitignore/i,
+    });
+    await generateButton.click();
+
+    // Wait for output
+    const toast = page.locator("[data-sonner-toast]").first();
+    await expect(toast).toBeVisible({ timeout: 5000 });
+
+    // Click clear button
+    const clearButton = page.getByRole("button", { name: /clear/i });
+    await clearButton.click();
+
+    // Copy button should no longer be visible (no output)
+    const copyButton = page.getByRole("button", {
+      name: /copy to clipboard/i,
+    });
+    await expect(copyButton).not.toBeVisible();
+  });
+
+  test("should filter templates by search query", async ({ page }) => {
+    await page.goto(REPRESENTATIVE_TOOL);
+
+    // Search for "python"
+    const searchInput = page.getByPlaceholder(
+      /search for languages, frameworks/i,
+    );
+    await searchInput.fill("python");
+
+    // Python button should be visible
+    const pythonButton = page.getByRole("button", {
+      name: "Python",
+      exact: true,
+    });
+    await expect(pythonButton).toBeVisible();
+
+    // Node button should NOT be visible
+    const nodeButton = page.getByRole("button", { name: "Node", exact: true });
+    await expect(nodeButton).not.toBeVisible();
+  });
+});

--- a/apps/codemata/tests/e2e/tools/generators.spec.ts
+++ b/apps/codemata/tests/e2e/tools/generators.spec.ts
@@ -20,8 +20,8 @@ test.describe("Generator Tools - Integration", () => {
     // Verify page loaded (partial match to handle title variations)
     await expect(page).toHaveTitle(/gitignore.*generator/i);
 
-    // Select a template (Node)
-    const nodeButton = page.getByRole("button", { name: "Node", exact: true });
+    // Select a template (Node.js)
+    const nodeButton = page.getByRole("button", { name: "Node.js" });
     await nodeButton.click();
 
     // Click the Generate button
@@ -30,9 +30,8 @@ test.describe("Generator Tools - Integration", () => {
     });
     await generateButton.click();
 
-    // Wait for success toast (indicates generation completed)
-    const toast = page.locator("[data-sonner-toast]").first();
-    await expect(toast).toBeVisible({ timeout: 5000 });
+    // Wait for generation to complete (button re-enabled)
+    await expect(generateButton).toBeEnabled({ timeout: 5000 });
 
     // Verify copy button is enabled (output exists)
     const copyButton = page.getByRole("button", {

--- a/apps/codemata/tests/e2e/tools/generators.spec.ts
+++ b/apps/codemata/tests/e2e/tools/generators.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+import { GENERATOR_TOOLS } from "../../../lib/tools-data";
+
+/**
+ * Generator Tools - Sample-Based Integration Tests
+ *
+ * Tests ONE representative generator to validate server action integration.
+ * Component behavior (checkbox interactions, template selection, output generation)
+ * is tested separately in components/gitignore-generator.spec.ts to avoid duplication.
+ *
+ * When adding new generators: Only add e2e tests if the tool introduces NEW behavior.
+ */
+
+test.describe("Generator Tools - Integration", () => {
+  const REPRESENTATIVE_TOOL = GENERATOR_TOOLS["gitignore-generator"];
+
+  test("should generate gitignore via server action", async ({ page }) => {
+    await page.goto(REPRESENTATIVE_TOOL.url);
+
+    // Verify page loaded (partial match to handle title variations)
+    await expect(page).toHaveTitle(/gitignore.*generator/i);
+
+    // Select a template (Node)
+    const nodeButton = page.getByRole("button", { name: "Node", exact: true });
+    await nodeButton.click();
+
+    // Click the Generate button
+    const generateButton = page.getByRole("button", {
+      name: /generate \.gitignore/i,
+    });
+    await generateButton.click();
+
+    // Wait for success toast (indicates generation completed)
+    const toast = page.locator("[data-sonner-toast]").first();
+    await expect(toast).toBeVisible({ timeout: 5000 });
+
+    // Verify copy button is enabled (output exists)
+    const copyButton = page.getByRole("button", {
+      name: /copy to clipboard/i,
+    });
+    await expect(copyButton).toBeEnabled();
+  });
+});


### PR DESCRIPTION
Add e2e test coverage for generators category following sample-based testing approach:

- Component tests (gitignore-generator.spec.ts): Template selection, search filtering, output generation, clear functionality
- Integration tests (generators.spec.ts): Server action validation

Mirrors existing pattern from minifiers/formatters (desktop-only, minimal coverage, tests user-facing behavior not business logic). Ensures new GitignoreGenerator component has same test coverage as other tool categories.